### PR TITLE
Added "Studio" RoomKind to enums.py and mila_schema.gql

### DIFF
--- a/milasdk/gql/enums.py
+++ b/milasdk/gql/enums.py
@@ -94,6 +94,7 @@ class RoomKind(StrEnum):
   MainBedroom = auto()
   KidsBedroom = auto()
   GuestBedroom = auto()
+  Studio = auto()
 
 class SoundsConfig(StrEnum):
   Enabled = auto()

--- a/milasdk/gql/mila_schema.gql
+++ b/milasdk/gql/mila_schema.gql
@@ -983,6 +983,7 @@ enum RoomKind {
   MainBedroom
   KidsBedroom
   GuestBedroom
+  Studio
 }
 
 type SafeguardAlert {


### PR DESCRIPTION
The MilaSDK has been throwing errors due to Mila's new room type (Studio). I have updated enums.py and the .gql file accordingly to patch this error.