### PR TITLE
Lock older version of gql

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     packages=find_namespace_packages(include=[base_package, f"{base_package}*"]),
     package_data={'': ['*.gql']},
     include_package_data=True,
-    install_requires=["aiohttp", "magicattr", "gql", "StrEnum","oauthlib","async_oauthlib"]
+    install_requires=["aiohttp", "magicattr", "gql<4", "StrEnum","oauthlib","async_oauthlib"]
 )


### PR DESCRIPTION
Use the older version of gql as it has breaking changes. Ideally fix the breaking changes and remove the lock in the future, but this should at least make it work.